### PR TITLE
Clone repos over SSH rather than HTTPS

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -69,7 +69,7 @@ function cloneOrPull(repo: string) {
 }
 
 function repoUrl(repo: string, org: string = 'prisma') {
-  return `https://github.com/${org}/${repo}.git`
+  return `git@github.com:${org}/${repo}.git`
 }
 
 export async function run(cwd: string, cmd: string): Promise<void> {


### PR DESCRIPTION
This makes it so you don't have to enter your Github password when you want to push